### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # YourStatusBar
 ## Customize the statusBar of your iOS app with any text or UIView
 [![Build Status](https://api.travis-ci.org/tapwork/YourStatusBar.svg?style=flat)](https://travis-ci.org/tapwork/YourStatusBar)
-[![Cocoapods Version](http://img.shields.io/cocoapods/v/YourStatusBar.svg?style=flat)](https://github.com/tapwork/YourStatusBar/blob/master/YourStatusBar.podspec)
+[![CocoaPods Version](http://img.shields.io/cocoapods/v/YourStatusBar.svg?style=flat)](https://github.com/tapwork/YourStatusBar/blob/master/YourStatusBar.podspec)
 [![](http://img.shields.io/cocoapods/l/YourStatusBar.svg?style=flat)](https://github.com/tapwork/YourStatusBar/blob/master/LICENSE.md)
 [![CocoaPods Platform](http://img.shields.io/cocoapods/p/YourStatusBar.svg?style=flat)]()
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
